### PR TITLE
standalone CALL to be readonly=true

### DIFF
--- a/src/include/parser/visitor/statement_read_write_analyzer.h
+++ b/src/include/parser/visitor/statement_read_write_analyzer.h
@@ -16,7 +16,7 @@ private:
     inline void visitDropTable(const Statement& /*statement*/) override { readOnly = false; }
     inline void visitAlter(const Statement& /*statement*/) override { readOnly = false; }
     inline void visitCopyFrom(const Statement& /*statement*/) override { readOnly = false; }
-    inline void visitStandaloneCall(const Statement& /*statement*/) override { readOnly = false; }
+    inline void visitStandaloneCall(const Statement& /*statement*/) override { readOnly = true; }
     inline void visitCreateMacro(const Statement& /*statement*/) override { readOnly = false; }
     inline void visitCommentOn(const Statement& /*statement*/) override { readOnly = false; }
 


### PR DESCRIPTION
Call which is used to set options is only possible in Read/Write connections and does not persist for the Db.

The means that settings cannot be set by a readonly connection. It seems like the majority of the time this doesn't make sense.

eg. in readonly mode we cannot use the followings
1. CALL enable_semi_mask=false;
1. CALL recursive_pattern_semantic='trail';
2. Any of the S3 settings (can't read from S3);
3. THREADS
4. TIMEOUT
5. VAR_LENGTH_EXTEND_MAX_DEPTH

All of these currently seem safe for read instances.